### PR TITLE
Fix bug where trash ../file would trash cwd

### DIFF
--- a/bin/trash
+++ b/bin/trash
@@ -187,7 +187,8 @@ if [ $# -gt 0 ]; then
 				if [ "${1:0:1}" = "/" ]; then
 					file="$1"
 				else
-					file="$(pwd)/$1"
+					# expand relative to absolute path
+					file=`ruby -e 'puts File.expand_path ARGV[0]' "$1"`
 				fi
 				if $verbose; then printf "Telling Finder to trash '%s'... " "$file"; fi
 				if /usr/bin/osascript -e "tell application \"Finder\" to delete POSIX file \"$file\"" ; then


### PR DESCRIPTION
Use ruby's File.expand_path to properly convert relative paths to absolute paths before sending to the Finder via AppleScript.

Previously, the absolute path was obtained with simple concatentation, such that `trash ../file` would be converted to `trash /path/to/cwd/../file`. When given this path, Finder would trash `/path/to/cwd` and then fail with an error. Yikes!

With ruby's File.expand_path, `trash ../file` is converted to `trash /path/to/file`, and Finder trashes the intended file.
