### PR TITLE
Fixed NUL bug in clipcat

### DIFF
--- a/src/clipcat
+++ b/src/clipcat
@@ -45,7 +45,8 @@ if ($ARGV[0]) {
         my $hex1 = substr $blob, 0, 2;
         my $hex2 = substr $blob, 2, 3;
         
-        print chr(hex($hex1)).chr(hex($hex2));
+        print chr(hex($hex1));
+        print chr(hex($hex2)) unless (hex($hex2) == 0);
       }
     }
   


### PR DESCRIPTION
If a textClipping contained an odd number of characters, `clipcat` would add an ASCII 0 NUL character on the end. This commit fixes this bug.
