### PR TITLE
Trash script prints output from osascript when trashing a file

### DIFF
--- a/src/trash
+++ b/src/trash
@@ -276,7 +276,7 @@ if [ $# -gt 0 ]; then
 						fi
 					fi
 					if $verbose; then printf "Telling Finder to trash '%s'... " "$file"; fi
-					if /usr/bin/osascript -e "tell application \"Finder\" to delete POSIX file \"$file\"" ; then
+					if /usr/bin/osascript -e "tell application \"Finder\" to delete POSIX file \"$file\"" &>/dev/null ; then
 						if $verbose; then printf "Done.\n"; fi
 					else
 						if $verbose; then printf "ERROR!\n"; fi


### PR DESCRIPTION
The trash script shows output from `osascript` when trashing a file. I redirected to `/dev/null/` to prevent this.

For example:

```
$ Desktop  > touch tmp
$ Desktop  > trash tmp 
document file tmp of item .Trash of folder joshvoigts of folder Users of startup disk
```

The last line is the extra output from `osascript`.
