### PR TITLE
fix around help message

### DIFF
--- a/src/dict
+++ b/src/dict
@@ -29,16 +29,14 @@ if ARGV.empty?
 else
   ARGV.each do |word|
   	# handle options
-  	if word =~ /^-/
-  	  word = case
-  	  when '-h':
-  	    puts <<-EOF
-  	  	  Usage: #{File.basename $0} [options] word ...
-            -v		verbose output
-            -h		print these usage instructions
-  	    EOF
-  	  end
-  	else
+    case word
+    when '-h' then
+      puts <<-EOF
+        Usage: #{File.basename $0} [options] word ...
+          -v    verbose output
+          -h    print these usage instructions
+      EOF
+    else
       definition word
     end
   end


### PR DESCRIPTION
An error occured when exec rake task.
This is message then.

```
mkdir ./bin
mkdir ./.tmp/
cp ./src/dict ./.tmp/dict.rb
/usr/local/bin/macrubyc -o ./bin/dict ./.tmp/dict.rb
./.tmp/dict.rb:34: syntax error, unexpected ':', expecting keyword_then or ',' or ';' or '\n'
./.tmp/dict.rb:41: syntax error, unexpected keyword_else, expecting keyword_end
./.tmp/dict.rb:45: syntax error, unexpected keyword_end, expecting $end
Error when executing ` arch -x86_64 /Library/Frameworks/MacRuby.framework/Versions/0.12/usr/bin/macruby  --emit-llvm "/var/folders/4r/jjx2r3gd0yl5ppyygxm773rr0000gn/T/dictx86_64-1585.bc" MREP_FF581DB8BD2C407D81D517B649FDE084 "./.tmp/dict.rb"'
rake aborted!
Command failed with status (1): [/usr/local/bin/macrubyc -o ./bin/dict ./.t...]
/Users/kitak/tools-osx/Rakefile:27:in `block in <top (required)>'
Tasks: TOP => default
(See full trace by running task with --trace)
```
