### PR TITLE
Suppress output clutter in `trash` command

### DIFF
--- a/src/trash
+++ b/src/trash
@@ -278,7 +278,7 @@ if [ $# -gt 0 ]; then
 						fi
 					fi
 					if $verbose; then printf "Telling Finder to trash '%s'... " "$file"; fi
-					if /usr/bin/osascript -e "tell application \"Finder\" to delete POSIX file \"$file\"" ; then
+					if /usr/bin/osascript -e "tell application \"Finder\" to delete POSIX file \"$file\"" >/dev/null ; then
 						if $verbose; then printf "Done.\n"; fi
 					else
 						if $verbose; then printf "ERROR!\n"; fi


### PR DESCRIPTION
Previously, the `trash` command would print out path information of the items it was deleting. This was unrelated to the verbose log messages `trash` would print when using the '-v' option, and cluttered the screen with long, AppleScript-style paths to the item in the ~/.Trash directory. For example, when trashing '~/Desktop/delme', `trash` would print:

```
folder delme of item .Trash of folder mtorok of folder Users of startup disk
```

This update suppresses the above messages by redirecting the output the `osascript` command to delete the file to `/dev/null`.

Again, this should not change any of the intentional messages `trash` prints, either in normal operations, or in verbose mode.
