### PR TITLE
Adding compatibility with Big Sur (macOS 11.0)

### DIFF
--- a/src/ql
+++ b/src/ql
@@ -12,7 +12,7 @@
 # 
 
 # Quick Look requires 10.5.x or higher
-if [ $(sw_vers -productVersion | cut -d . -f 2) -lt 5 ]; then
+if [ $(sw_vers -productVersion | cut -d . -f 2) -lt 5 ] && [ $(sw_vers -productVersion | cut -d . -f 1) -lt 11 ]; then
 	echo "Quick Look requires Mac OS X 10.5 Leopard or newer."
 	exit 1
 fi


### PR DESCRIPTION
ql also works in macOS Big Sur (11.0), but the current checker was not aware of it as only checked for the 10.X numbers.