### PR TITLE
Add instructions for installing just the `trash` shell script

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ INSTALLATION
 2. Run `rake`.
 3. Run `sudo rake install`. (If you have write permission on `/usr/local/bin`, you don’t need to `sudo`.)
 
+## Installing only `trash` as a shell script
+
+Using [zinit](https://github.com/zdharma/zinit), you can install just the `trash` shell script by adding this to your `.zshrc` file
+
+```shell
+zinit wait'1' lucid light-mode as"program" pick"src/trash" for morgant/tools-osx
+```
+
 OTHER TOOLS
 -----------
 


### PR DESCRIPTION
Some, like me, are only interested in the `trash` shell script, and this documents one way of installing just that, without any build procedure.

This `trash` command is, in my opinion, the best one out there for macOS. However, others are more easily installed (e.g. through `brew install trash`) and are therefore, unfortunately, more widely used.
