### PR TITLE
Remove custom realpath script

### DIFF
--- a/src/trash
+++ b/src/trash
@@ -78,73 +78,6 @@ function have_scriptable_finder() {
 	fi
 }
 
-## 
-## Convert a relative path to an absolute path.
-## 
-## From http://github.com/morgant/realpath
-## 
-## @param string the string to converted from a relative path to an absolute path
-## @returns Outputs the absolute path to STDOUT, returns 0 if successful or 1 if an error (esp. path not found).
-## 
-function realpath()
-{
-	local success=true
-	local path="$1"
-	
-	# make sure the string isn't empty as that implies something in further logic
-	if [ -z "$path" ]; then
-		success=false
-	else
-		# start with the file name (sans the trailing slash)
-		path="${path%/}"
-		
-		# if we stripped off the trailing slash and were left with nothing, that means we're in the root directory
-		if [ -z "$path" ]; then
-			path="/"
-		fi
-		
-		# get the basename of the file (ignoring '.' & '..', because they're really part of the path)
-		local file_basename="${path##*/}"
-		if [[ ( "$file_basename" = "." ) || ( "$file_basename" = ".." ) ]]; then
-			file_basename=""
-		fi
-		
-		# extracts the directory component of the full path, if it's empty then assume '.' (the current working directory)
-		local directory="${path%$file_basename}"
-		if [ -z "$directory" ]; then
-			directory='.'
-		fi
-		
-		# attempt to change to the directory
-		if ! cd "$directory" &>/dev/null ; then
-			success=false
-		fi
-		
-		if $success; then
-			# does the filename exist?
-			if [[ ( -n "$file_basename" ) && ( ! -e "$file_basename" ) ]]; then
-				success=false
-			fi
-			
-			# get the absolute path of the current directory & change back to previous directory
-			local abs_path="$(pwd -P)"
-			cd "-" &>/dev/null
-			  
-			# Append base filename to absolute path
-			if [ "${abs_path}" = "/" ]; then
-				abs_path="${abs_path}${file_basename}"
-			else
-				abs_path="${abs_path}/${file_basename}"
-			fi
-			
-			# output the absolute path
-			echo "$abs_path"
-		fi
-	fi
-	
-	$success
-}
-
 if ! have_full_disk_access ; then
   printf "%s requires Full Disk Access!\n\n" "$(basename "$0")"
   printf "Please go to System Preferences > Security & Privacy > Privacy > Full Disk Access,\n"
@@ -296,7 +229,7 @@ if [ $# -gt 0 ]; then
 					else
 						# expand relative to absolute path
 						if $verbose; then printf "Determining absolute path for '%s'... " "$1"; fi
-						file="$(realpath "$1")"
+						file="$(/bin/realpath "$1")"
 						if [ $? -eq 0 ]; then
 							if $verbose; then printf "Done.\n"; fi
 						else


### PR DESCRIPTION
`realpath` was added to the standard library on macOS in version 13.

I've updated reference to realpath to use the full path at `/bin/realpath`.